### PR TITLE
Set up code checks on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,32 @@
+version: 2.1
+
+jobs:
+  run_checks:
+    docker:
+      - image: python:3.8
+    working_directory: ~/project/partner
+    parameters:
+      tox_env:
+        type: string
+    steps:
+      - checkout:
+          path: ~/project/
+      - run:
+          name: Install tox
+          command: |
+            python -m pip install --upgrade pip
+            python -m pip install tox
+      - run:
+          name: Run tox
+          command: |
+            tox -e << parameters.tox_env >>
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - run_checks:
+          name: Run checks << matrix.tox_env >> 🤖
+          matrix:
+            parameters:
+              tox_env: ["black", "flake8", "mypy", "py38"]

--- a/partner/dev-requirements.in
+++ b/partner/dev-requirements.in
@@ -4,3 +4,4 @@ flake8
 isort
 mypy
 pytest
+requests

--- a/partner/dev-requirements.txt
+++ b/partner/dev-requirements.txt
@@ -10,19 +10,18 @@ attrs==21.2.0
     # via pytest
 black==21.5b2
     # via -r dev-requirements.in
+certifi==2021.5.30
+    # via requests
+chardet==4.0.0
+    # via requests
 click==8.0.1
     # via
     #   -c requirements.txt
     #   black
 flake8==3.9.2
     # via -r dev-requirements.in
-importlib-metadata==4.5.0
-    # via
-    #   -c requirements.txt
-    #   click
-    #   flake8
-    #   pluggy
-    #   pytest
+idna==2.10
+    # via requests
 iniconfig==1.1.1
     # via pytest
 isort==5.8.0
@@ -53,21 +52,17 @@ pytest==6.2.4
     # via -r dev-requirements.in
 regex==2021.4.4
     # via black
+requests==2.25.1
+    # via -r dev-requirements.in
 toml==0.10.2
     # via
     #   black
     #   pytest
 typed-ast==1.4.3
-    # via
-    #   black
-    #   mypy
+    # via mypy
 typing-extensions==3.10.0.0
     # via
     #   -c requirements.txt
-    #   black
-    #   importlib-metadata
     #   mypy
-zipp==3.4.1
-    # via
-    #   -c requirements.txt
-    #   importlib-metadata
+urllib3==1.26.5
+    # via requests

--- a/partner/mypy.ini
+++ b/partner/mypy.ini
@@ -1,0 +1,10 @@
+[mypy]
+python_version=3.8
+follow_imports=normal
+ignore_missing_imports=True
+disallow_untyped_calls=True
+warn_return_any=True
+strict_optional=True
+warn_no_return=True
+warn_redundant_casts=True
+warn_unused_ignores=True

--- a/partner/tox.ini
+++ b/partner/tox.ini
@@ -1,0 +1,47 @@
+[tox]
+envlist = black, flake8, mypy, py38
+isolated_build = False
+
+[testenv]
+# Use Python 3.8 for all test environments
+basepython = python3.8
+
+# The app is not set up as a Python package
+skip_install = True
+
+# We use pip-tools to install compatible packages
+deps = pip-tools
+
+[testenv:py38]
+commands_pre =
+    # Install the pinned app and development requirements
+    pip-sync {toxinidir}/requirements.txt {toxinidir}/dev-requirements.txt
+    # Verify installed packages have compatible dependencies
+    pip check -v
+commands =
+    # Run the unit tests
+    pytest -v {posargs:app/tests}
+
+[testenv:black]
+commands_pre =
+    # Install the pinned development requirements
+    pip-sync {toxinidir}/dev-requirements.txt
+commands =
+    black --check app/
+
+[testenv:flake8]
+commands_pre =
+    # Install the pinned development requirements
+    pip-sync {toxinidir}/dev-requirements.txt
+commands =
+    flake8
+
+[flake8]
+max-line-length = 88
+
+[testenv:mypy]
+commands_pre =
+    # Install the pinned development requirements
+    pip-sync {toxinidir}/dev-requirements.txt
+commands =
+    mypy app/


### PR DESCRIPTION
This pull-request adds several configuration files for running code checks via tox on CircleCI.

If this works as planned, we will see one failing check for flake8.