### PR TITLE
Add volumes for all services 

### DIFF
--- a/volumes/client/scenarios.yml
+++ b/volumes/client/scenarios.yml
@@ -1,0 +1,176 @@
+scenarios:
+  - name: success_desktop_windows
+    description: Test that Contile successfully returns tiles for Windows on Desktop.
+    steps:
+      - request:
+          method: GET
+          path: '/v1/tiles'
+          headers:
+            # Contile maps the User-Agent Header value to os-family and form-factor parameters
+            # The following value will result in os-family: windows and form-factor: desktop
+            - name: User-Agent
+              value: 'Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/10.0'
+        response:
+          status_code: 200
+          content:
+            tiles:
+              - id: 12345
+                name: 'Example'
+                click_url: 'https://example.com/desktop_windows?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+                image_url: 'https://example.com/desktop_windows01.jpg'
+                impression_url: 'https://example.com/desktop_windows?id=0001'
+                url: 'https://www.example.com/desktop_windows'
+                position: 1
+              - id: 56789
+                name: 'Example'
+                click_url: 'https://example.com/desktop_windows?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+                image_url: 'https://example.com/desktop_windows02.jpg'
+                impression_url: 'https://example.com/desktop_windows?id=0002'
+                url: 'https://www.example.com/desktop_windows'
+                position: 1
+      - request:
+          method: GET
+          path: '/v1/tiles'
+          headers:
+            # Contile maps the User-Agent Header value to os-family and form-factor parameters
+            # The following value will result in os-family: windows and form-factor: desktop
+            - name: User-Agent
+              value: 'Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/10.0'
+        response:
+          status_code: 200
+          content:
+            tiles:
+              - id: 12345
+                name: 'Example'
+                click_url: 'https://example.com/desktop_windows?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+                image_url: 'https://example.com/desktop_windows01.jpg'
+                impression_url: 'https://example.com/desktop_windows?id=0001'
+                url: 'https://www.example.com/desktop_windows'
+                position: 1
+              - id: 56789
+                name: 'Example'
+                click_url: 'https://example.com/desktop_windows?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+                image_url: 'https://example.com/desktop_windows02.jpg'
+                impression_url: 'https://example.com/desktop_windows?id=0002'
+                url: 'https://www.example.com/desktop_windows'
+                position: 1
+
+  - name: success_desktop_macos_cached_from_windows
+    description: Test that Contile successfully returns cached Windows tiles for macOS on Desktop.
+    steps:
+      - request:
+          method: GET
+          path: '/v1/tiles'
+          headers:
+            # Contile maps the User-Agent Header value to os-family and form-factor parameters
+            # The following value will result in os-family: macos and form-factor: desktop
+            - name: User-Agent
+              value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:10.0) Gecko/20100101 Firefox/10.0'
+        response:
+          status_code: 200
+          content:
+            tiles:
+              - id: 12345
+                name: 'Example'
+                click_url: 'https://example.com/desktop_windows?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+                image_url: 'https://example.com/desktop_windows01.jpg'
+                impression_url: 'https://example.com/desktop_windows?id=0001'
+                url: 'https://www.example.com/desktop_windows'
+                position: 1
+              - id: 56789
+                name: 'Example'
+                click_url: 'https://example.com/desktop_windows?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+                image_url: 'https://example.com/desktop_windows02.jpg'
+                impression_url: 'https://example.com/desktop_windows?id=0002'
+                url: 'https://www.example.com/desktop_windows'
+                position: 1
+
+  - name: success_desktop_linux_cached_from_windows
+    description: Test that Contile successfully returns cached Windows tiles for Linux on Desktop.
+    steps:
+      - request:
+          method: GET
+          path: '/v1/tiles'
+          headers:
+            # Contile maps the User-Agent Header value to os-family and form-factor parameters
+            # The following value will result in os-family: linux and form-factor: desktop
+            - name: User-Agent
+              value: 'Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0'
+        response:
+          status_code: 200
+          content:
+            tiles:
+              - id: 12345
+                name: 'Example'
+                click_url: 'https://example.com/desktop_windows?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+                image_url: 'https://example.com/desktop_windows01.jpg'
+                impression_url: 'https://example.com/desktop_windows?id=0001'
+                url: 'https://www.example.com/desktop_windows'
+                position: 1
+              - id: 56789
+                name: 'Example'
+                click_url: 'https://example.com/desktop_windows?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+                image_url: 'https://example.com/desktop_windows02.jpg'
+                impression_url: 'https://example.com/desktop_windows?id=0002'
+                url: 'https://www.example.com/desktop_windows'
+                position: 1
+
+  - name: error_phone_android_reqwest_error
+    description: Test that Contile correctly handles a 500 from the partner API.
+    steps:
+      - request:
+          method: GET
+          path: '/v1/tiles'
+          headers:
+            # Contile maps the User-Agent Header value to os-family and form-factor parameters
+            # The following value will result in os-family: android and form-factor: phone
+            - name: User-Agent
+              value: 'Mozilla/5.0 (Android; Mobile; rv:40.0) Gecko/40.0 Firefox/40.0'
+        response:
+          status_code: 500 # Internal Server Error
+          content: 520
+
+  - name: error_tablet_ios_reqwest_error
+    description: Test that Contile correctly handles invalid tiles responses from the partner API.
+    steps:
+      - request:
+          method: GET
+          path: '/v1/tiles'
+          headers:
+            # Contile maps the User-Agent Header value to os-family and form-factor parameters
+            # The following value will result in os-family: ios and form-factor: tablet
+            - name: User-Agent
+              value: 'Mozilla/5.0 (iPad; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4'
+        response:
+          status_code: 204 # No Content
+          content: ''
+
+  - name: error_phone_ios_timeout
+    description: Test that Contile behaves correctly when a request to the partner API times out.
+    steps:
+      - request:
+          method: GET
+          path: '/v1/tiles'
+          headers:
+            # Contile maps the User-Agent Header value to os-family and form-factor parameters
+            # The following value will result in os-family: ios and form-factor: phone
+            - name: User-Agent
+              value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4'
+        response:
+          status_code: 503 # Service Unavailable
+          content: 522
+
+  - name: error_invalid_user_agent
+    description: Test that Contile correctly handles requests from non Firefox clients.
+    steps:
+      - request:
+          method: GET
+          path: '/v1/tiles'
+          headers:
+            # Contile maps the User-Agent Header value to os-family and form-factor parameters
+            # The following value will result in os-family: macos and form-factor: desktop
+            - name: User-Agent
+              value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1 Safari/605.1.15'
+        response:
+          status_code: 403 # Forbidden
+          content: 700

--- a/volumes/contile/adm_settings.json
+++ b/volumes/contile/adm_settings.json
@@ -1,0 +1,42 @@
+{
+    "Example": {
+        "advertiser_hosts": [
+            "www.example.com",
+            "www.example.co.uk",
+            "www.example.it",
+            "www.example.com.au",
+            "www.example.ca",
+            "www.example.de",
+            "www.example.fr",
+            "www.example.es",
+            "www.example.in",
+            "www.example.com.mx"
+        ],
+        "click_hosts": [],
+        "impression_hosts": [],
+        "include_regions": [],
+        "position": 1
+    },
+    "DEFAULT": {
+        "advertiser_hosts": [],
+        "click_hosts": [
+            "example.com"
+        ],
+        "impression_hosts": [
+            "example.com"
+        ],
+        "include_regions": [
+            "US",
+            "GB",
+            "IT",
+            "AU",
+            "CA",
+            "DE",
+            "FR",
+            "ES",
+            "IN",
+            "MX",
+            "CN"
+        ]
+    }
+}

--- a/volumes/partner/responses.yml
+++ b/volumes/partner/responses.yml
@@ -1,0 +1,87 @@
+# This file contains all partner responses for the /tilesp API endpoint.
+# We use form-factor and os-family to determine which response to send to Contile.
+desktop:
+    windows:
+      status_code: 200
+      headers: []
+      content:
+        tiles:
+          - id: 12345
+            name: 'Example'
+            click_url: 'https://example.com/desktop_windows?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+            image_url: 'https://example.com/desktop_windows01.jpg'
+            impression_url: 'https://example.com/desktop_windows?id=0001'
+            advertiser_url: 'https://www.example.com/desktop_windows'
+          - id: 56789
+            name: 'Example'
+            click_url: 'https://example.com/desktop_windows?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+            image_url: 'https://example.com/desktop_windows02.jpg'
+            impression_url: 'https://example.com/desktop_windows?id=0002'
+            advertiser_url: 'https://www.example.com/desktop_windows'
+
+    macos:
+      status_code: 200
+      headers: []
+      content:
+        tiles:
+          - id: 12346
+            name: 'Example'
+            click_url: 'https://example.com/desktop_macos?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+            image_url: 'https://example.com/desktop_macos01.jpg'
+            impression_url: 'https://example.com/desktop_macos?id=0001'
+            advertiser_url: 'https://www.example.com/desktop_macos'
+          - id: 56790
+            name: 'Example'
+            click_url: 'https://example.com/desktop_macos?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+            image_url: 'https://example.com/desktop_macos02.jpg'
+            impression_url: 'https://example.com/desktop_macos?id=0002'
+            advertiser_url: 'https://www.example.com/desktop_macos'
+
+    linux:
+      status_code: 200
+      headers: []
+      content:
+        tiles:
+          - id: 12347
+            name: 'Example'
+            click_url: 'https://example.com/desktop_linux?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+            image_url: 'https://example.com/desktop_linux01.jpg'
+            impression_url: 'https://example.com/desktop_linux?id=0001'
+            advertiser_url: 'https://www.example.com/desktop_linux'
+          - id: 56791
+            name: 'Example'
+            click_url: 'https://example.com/desktop_linux?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+            image_url: 'https://example.com/desktop_linux02.jpg'
+            impression_url: 'https://example.com/desktop_linux?id=0002'
+            advertiser_url: 'https://www.example.com/desktop_linux'
+
+phone:
+    android:
+      status_code: 500
+      headers: []
+      content: {}
+
+    ios:
+      delay: 5.0
+      status_code: 200
+      headers: []
+      content:
+        tiles:
+          - id: 12348
+            name: 'Example'
+            click_url: 'https://example.com/desktop_ios?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+            image_url: 'https://example.com/desktop_ios01.jpg'
+            impression_url: 'https://example.com/desktop_ios?id=0001'
+            advertiser_url: 'https://www.example.com/desktop_ios'
+          - id: 56792
+            name: 'Example'
+            click_url: 'https://example.com/desktop_ios?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+            image_url: 'https://example.com/desktop_ios02.jpg'
+            impression_url: 'https://example.com/desktop_ios?id=0002'
+            advertiser_url: 'https://www.example.com/desktop_ios'
+
+tablet:
+    ios:
+      status_code: 200
+      headers: []
+      content: "hello world"


### PR DESCRIPTION
This pull request is the next one in a series of pull requests adding a working integration test suite (see also #9, #10, #13).

It adds a new `volumes` directory which contains subdirectories which will be mounted as volumes into the Docker containers used in the integration test suite:

- the `volumes/partner` directory contains a YML file which defines every response that the API returns keyed by form-factor and then os-family
- the `volumes/contile` directory contains files that need to be provided to a MTS Docker container such as a partner settings file
- the `volumes/client` directory contains a YML file which defines every test scenario that the integration test suite will run

The files in the `volumes` directory  as well as the `docker-compose.yml` file in this repository are checked in only for local development and demonstration purposes. Similar files will be checked in to https://github.com/mozilla-services/contile.