### PR TITLE
Add second tiles advertiser to examples 📋

### DIFF
--- a/partner/README.md
+++ b/partner/README.md
@@ -49,7 +49,7 @@ Example response body:
   "tiles": [
     {
       "id": 12346,
-      "name": "Example",
+      "name": "Example COM",
       "click_url": "https://example.com/desktop_macos?version=16.0.0",
       "image_url": "https://example.com/desktop_macos01.jpg",
       "impression_url": "https://example.com/desktop_macos?id=0001",
@@ -57,11 +57,11 @@ Example response body:
     },
     {
       "id": 56790,
-      "name": "Example",
-      "click_url": "https://example.com/desktop_macos?version=16.0.0",
-      "image_url": "https://example.com/desktop_macos02.jpg",
-      "impression_url": "https://example.com/desktop_macos?id=0002",
-      "advertiser_url": "https://www.example.com/desktop_macos"
+      "name": "Example ORG",
+      "click_url": "https://example.org/desktop_macos?version=16.0.0",
+      "image_url": "https://example.org/desktop_macos02.jpg",
+      "impression_url": "https://example.org/desktop_macos?id=0002",
+      "advertiser_url": "https://www.example.org/desktop_macos"
     }
   ]
 }

--- a/partner/app/tests/responses.yml
+++ b/partner/app/tests/responses.yml
@@ -7,14 +7,14 @@ desktop:
       content:
         tiles:
           - id: 12346
-            name: 'Example'
+            name: 'Example COM'
             click_url: 'https://example.com/desktop_macos?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
             image_url: 'https://example.com/desktop_macos01.jpg'
             impression_url: 'https://example.com/desktop_macos?id=0001'
             advertiser_url: 'https://www.example.com/desktop_macos'
           - id: 56790
-            name: 'Example'
-            click_url: 'https://example.com/desktop_macos?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
-            image_url: 'https://example.com/desktop_macos02.jpg'
-            impression_url: 'https://example.com/desktop_macos?id=0002'
-            advertiser_url: 'https://www.example.com/desktop_macos'
+            name: 'Example ORG'
+            click_url: 'https://example.org/desktop_macos?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+            image_url: 'https://example.org/desktop_macos02.jpg'
+            impression_url: 'https://example.org/desktop_macos?id=0002'
+            advertiser_url: 'https://www.example.org/desktop_macos'

--- a/partner/app/tests/test_app.py
+++ b/partner/app/tests/test_app.py
@@ -35,7 +35,7 @@ def test_read_tilesp(client):
         "tiles": [
             {
                 "id": 12346,
-                "name": "Example",
+                "name": "Example COM",
                 "click_url": "https://example.com/desktop_macos?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000",
                 "image_url": "https://example.com/desktop_macos01.jpg",
                 "impression_url": "https://example.com/desktop_macos?id=0001",
@@ -43,11 +43,11 @@ def test_read_tilesp(client):
             },
             {
                 "id": 56790,
-                "name": "Example",
-                "click_url": "https://example.com/desktop_macos?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A",
-                "image_url": "https://example.com/desktop_macos02.jpg",
-                "impression_url": "https://example.com/desktop_macos?id=0002",
-                "advertiser_url": "https://www.example.com/desktop_macos",
+                "name": "Example ORG",
+                "click_url": "https://example.org/desktop_macos?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A",
+                "image_url": "https://example.org/desktop_macos02.jpg",
+                "impression_url": "https://example.org/desktop_macos?id=0002",
+                "advertiser_url": "https://www.example.org/desktop_macos",
             },
         ]
     }

--- a/volumes/client/scenarios.yml
+++ b/volumes/client/scenarios.yml
@@ -15,18 +15,18 @@ scenarios:
           content:
             tiles:
               - id: 12345
-                name: 'Example'
+                name: 'Example COM'
                 click_url: 'https://example.com/desktop_windows?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
                 image_url: 'https://example.com/desktop_windows01.jpg'
                 impression_url: 'https://example.com/desktop_windows?id=0001'
                 url: 'https://www.example.com/desktop_windows'
                 position: 1
               - id: 56789
-                name: 'Example'
-                click_url: 'https://example.com/desktop_windows?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
-                image_url: 'https://example.com/desktop_windows02.jpg'
-                impression_url: 'https://example.com/desktop_windows?id=0002'
-                url: 'https://www.example.com/desktop_windows'
+                name: 'Example ORG'
+                click_url: 'https://example.org/desktop_windows?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+                image_url: 'https://example.org/desktop_windows02.jpg'
+                impression_url: 'https://example.org/desktop_windows?id=0002'
+                url: 'https://www.example.org/desktop_windows'
                 position: 1
       - request:
           method: GET
@@ -41,18 +41,18 @@ scenarios:
           content:
             tiles:
               - id: 12345
-                name: 'Example'
+                name: 'Example COM'
                 click_url: 'https://example.com/desktop_windows?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
                 image_url: 'https://example.com/desktop_windows01.jpg'
                 impression_url: 'https://example.com/desktop_windows?id=0001'
                 url: 'https://www.example.com/desktop_windows'
                 position: 1
               - id: 56789
-                name: 'Example'
-                click_url: 'https://example.com/desktop_windows?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
-                image_url: 'https://example.com/desktop_windows02.jpg'
-                impression_url: 'https://example.com/desktop_windows?id=0002'
-                url: 'https://www.example.com/desktop_windows'
+                name: 'Example ORG'
+                click_url: 'https://example.org/desktop_windows?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+                image_url: 'https://example.org/desktop_windows02.jpg'
+                impression_url: 'https://example.org/desktop_windows?id=0002'
+                url: 'https://www.example.org/desktop_windows'
                 position: 1
 
   - name: success_desktop_macos_cached_from_windows
@@ -71,18 +71,18 @@ scenarios:
           content:
             tiles:
               - id: 12345
-                name: 'Example'
+                name: 'Example COM'
                 click_url: 'https://example.com/desktop_windows?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
                 image_url: 'https://example.com/desktop_windows01.jpg'
                 impression_url: 'https://example.com/desktop_windows?id=0001'
                 url: 'https://www.example.com/desktop_windows'
                 position: 1
               - id: 56789
-                name: 'Example'
-                click_url: 'https://example.com/desktop_windows?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
-                image_url: 'https://example.com/desktop_windows02.jpg'
-                impression_url: 'https://example.com/desktop_windows?id=0002'
-                url: 'https://www.example.com/desktop_windows'
+                name: 'Example ORG'
+                click_url: 'https://example.org/desktop_windows?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+                image_url: 'https://example.org/desktop_windows02.jpg'
+                impression_url: 'https://example.org/desktop_windows?id=0002'
+                url: 'https://www.example.org/desktop_windows'
                 position: 1
 
   - name: success_desktop_linux_cached_from_windows
@@ -101,18 +101,18 @@ scenarios:
           content:
             tiles:
               - id: 12345
-                name: 'Example'
+                name: 'Example COM'
                 click_url: 'https://example.com/desktop_windows?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
                 image_url: 'https://example.com/desktop_windows01.jpg'
                 impression_url: 'https://example.com/desktop_windows?id=0001'
                 url: 'https://www.example.com/desktop_windows'
                 position: 1
               - id: 56789
-                name: 'Example'
-                click_url: 'https://example.com/desktop_windows?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
-                image_url: 'https://example.com/desktop_windows02.jpg'
-                impression_url: 'https://example.com/desktop_windows?id=0002'
-                url: 'https://www.example.com/desktop_windows'
+                name: 'Example ORG'
+                click_url: 'https://example.org/desktop_windows?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+                image_url: 'https://example.org/desktop_windows02.jpg'
+                impression_url: 'https://example.org/desktop_windows?id=0002'
+                url: 'https://www.example.org/desktop_windows'
                 position: 1
 
   - name: error_phone_android_reqwest_error

--- a/volumes/contile/adm_settings.json
+++ b/volumes/contile/adm_settings.json
@@ -1,5 +1,5 @@
 {
-    "Example": {
+    "Example COM": {
         "advertiser_hosts": [
             "www.example.com",
             "www.example.co.uk",
@@ -14,6 +14,19 @@
         ],
         "click_hosts": [],
         "impression_hosts": [],
+        "include_regions": [],
+        "position": 1
+    },
+    "Example ORG": {
+        "advertiser_hosts": [
+            "www.example.org"
+        ],
+        "click_hosts": [
+            "example.org"
+        ],
+        "impression_hosts": [
+            "example.org"
+        ],
         "include_regions": [],
         "position": 1
     },

--- a/volumes/partner/responses.yml
+++ b/volumes/partner/responses.yml
@@ -7,17 +7,17 @@ desktop:
       content:
         tiles:
           - id: 12345
-            name: 'Example'
+            name: 'Example COM'
             click_url: 'https://example.com/desktop_windows?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
             image_url: 'https://example.com/desktop_windows01.jpg'
             impression_url: 'https://example.com/desktop_windows?id=0001'
             advertiser_url: 'https://www.example.com/desktop_windows'
           - id: 56789
-            name: 'Example'
-            click_url: 'https://example.com/desktop_windows?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
-            image_url: 'https://example.com/desktop_windows02.jpg'
-            impression_url: 'https://example.com/desktop_windows?id=0002'
-            advertiser_url: 'https://www.example.com/desktop_windows'
+            name: 'Example ORG'
+            click_url: 'https://example.org/desktop_windows?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+            image_url: 'https://example.org/desktop_windows02.jpg'
+            impression_url: 'https://example.org/desktop_windows?id=0002'
+            advertiser_url: 'https://www.example.org/desktop_windows'
 
     macos:
       status_code: 200
@@ -25,17 +25,17 @@ desktop:
       content:
         tiles:
           - id: 12346
-            name: 'Example'
+            name: 'Example COM'
             click_url: 'https://example.com/desktop_macos?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
             image_url: 'https://example.com/desktop_macos01.jpg'
             impression_url: 'https://example.com/desktop_macos?id=0001'
             advertiser_url: 'https://www.example.com/desktop_macos'
           - id: 56790
-            name: 'Example'
-            click_url: 'https://example.com/desktop_macos?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
-            image_url: 'https://example.com/desktop_macos02.jpg'
-            impression_url: 'https://example.com/desktop_macos?id=0002'
-            advertiser_url: 'https://www.example.com/desktop_macos'
+            name: 'Example ORG'
+            click_url: 'https://example.org/desktop_macos?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+            image_url: 'https://example.org/desktop_macos02.jpg'
+            impression_url: 'https://example.org/desktop_macos?id=0002'
+            advertiser_url: 'https://www.example.org/desktop_macos'
 
     linux:
       status_code: 200
@@ -43,17 +43,17 @@ desktop:
       content:
         tiles:
           - id: 12347
-            name: 'Example'
+            name: 'Example COM'
             click_url: 'https://example.com/desktop_linux?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
             image_url: 'https://example.com/desktop_linux01.jpg'
             impression_url: 'https://example.com/desktop_linux?id=0001'
             advertiser_url: 'https://www.example.com/desktop_linux'
           - id: 56791
-            name: 'Example'
-            click_url: 'https://example.com/desktop_linux?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
-            image_url: 'https://example.com/desktop_linux02.jpg'
-            impression_url: 'https://example.com/desktop_linux?id=0002'
-            advertiser_url: 'https://www.example.com/desktop_linux'
+            name: 'Example ORG'
+            click_url: 'https://example.org/desktop_linux?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+            image_url: 'https://example.org/desktop_linux02.jpg'
+            impression_url: 'https://example.org/desktop_linux?id=0002'
+            advertiser_url: 'https://www.example.org/desktop_linux'
 
 phone:
     android:
@@ -68,17 +68,17 @@ phone:
       content:
         tiles:
           - id: 12348
-            name: 'Example'
+            name: 'Example COM'
             click_url: 'https://example.com/desktop_ios?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
             image_url: 'https://example.com/desktop_ios01.jpg'
             impression_url: 'https://example.com/desktop_ios?id=0001'
             advertiser_url: 'https://www.example.com/desktop_ios'
           - id: 56792
-            name: 'Example'
-            click_url: 'https://example.com/desktop_ios?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
-            image_url: 'https://example.com/desktop_ios02.jpg'
-            impression_url: 'https://example.com/desktop_ios?id=0002'
-            advertiser_url: 'https://www.example.com/desktop_ios'
+            name: 'Example ORG'
+            click_url: 'https://example.org/desktop_ios?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+            image_url: 'https://example.org/desktop_ios02.jpg'
+            impression_url: 'https://example.org/desktop_ios?id=0002'
+            advertiser_url: 'https://www.example.org/desktop_ios'
 
 tablet:
     ios:


### PR DESCRIPTION
This pull request updates the various files in the project that contain tiles information. With these changes in place the partner API effectively returns a second advertiser which is different from `example.com` as suggested by @pjenvey in https://github.com/mozilla-services/contile-integration-tests/pull/10#discussion_r658917361.

Resolve #17 