### PR TITLE
Add image_size to contile model 📐 

### DIFF
--- a/client/tests/models.py
+++ b/client/tests/models.py
@@ -4,7 +4,7 @@
 
 from typing import Any, List, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Extra
 
 
 class Header(BaseModel):
@@ -22,7 +22,7 @@ class Request(BaseModel):
     headers: List[Header] = []
 
 
-class Tile(BaseModel):
+class Tile(BaseModel, extra=Extra.allow):
     """Class that holds information about a Tile returned by Contile."""
 
     id: int

--- a/client/tests/models.py
+++ b/client/tests/models.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from typing import Any, List, Union
+from typing import Any, List, Optional, Union
 
 from pydantic import BaseModel, Extra
 
@@ -29,6 +29,7 @@ class Tile(BaseModel, extra=Extra.allow):
     name: str
     click_url: str
     image_url: str
+    image_size: Optional[int]
     impression_url: str
     url: str
     position: int

--- a/volumes/client/scenarios.yml
+++ b/volumes/client/scenarios.yml
@@ -18,6 +18,7 @@ scenarios:
                 name: 'Example COM'
                 click_url: 'https://example.com/desktop_windows?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
                 image_url: 'https://example.com/desktop_windows01.jpg'
+                image_size: null
                 impression_url: 'https://example.com/desktop_windows?id=0001'
                 url: 'https://www.example.com/desktop_windows'
                 position: 1
@@ -25,6 +26,7 @@ scenarios:
                 name: 'Example ORG'
                 click_url: 'https://example.org/desktop_windows?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
                 image_url: 'https://example.org/desktop_windows02.jpg'
+                image_size: null
                 impression_url: 'https://example.org/desktop_windows?id=0002'
                 url: 'https://www.example.org/desktop_windows'
                 position: 1
@@ -44,6 +46,7 @@ scenarios:
                 name: 'Example COM'
                 click_url: 'https://example.com/desktop_windows?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
                 image_url: 'https://example.com/desktop_windows01.jpg'
+                image_size: null
                 impression_url: 'https://example.com/desktop_windows?id=0001'
                 url: 'https://www.example.com/desktop_windows'
                 position: 1
@@ -51,6 +54,7 @@ scenarios:
                 name: 'Example ORG'
                 click_url: 'https://example.org/desktop_windows?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
                 image_url: 'https://example.org/desktop_windows02.jpg'
+                image_size: null
                 impression_url: 'https://example.org/desktop_windows?id=0002'
                 url: 'https://www.example.org/desktop_windows'
                 position: 1
@@ -74,6 +78,7 @@ scenarios:
                 name: 'Example COM'
                 click_url: 'https://example.com/desktop_windows?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
                 image_url: 'https://example.com/desktop_windows01.jpg'
+                image_size: null
                 impression_url: 'https://example.com/desktop_windows?id=0001'
                 url: 'https://www.example.com/desktop_windows'
                 position: 1
@@ -81,6 +86,7 @@ scenarios:
                 name: 'Example ORG'
                 click_url: 'https://example.org/desktop_windows?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
                 image_url: 'https://example.org/desktop_windows02.jpg'
+                image_size: null
                 impression_url: 'https://example.org/desktop_windows?id=0002'
                 url: 'https://www.example.org/desktop_windows'
                 position: 1
@@ -104,6 +110,7 @@ scenarios:
                 name: 'Example COM'
                 click_url: 'https://example.com/desktop_windows?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
                 image_url: 'https://example.com/desktop_windows01.jpg'
+                image_size: null
                 impression_url: 'https://example.com/desktop_windows?id=0001'
                 url: 'https://www.example.com/desktop_windows'
                 position: 1
@@ -111,6 +118,7 @@ scenarios:
                 name: 'Example ORG'
                 click_url: 'https://example.org/desktop_windows?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
                 image_url: 'https://example.org/desktop_windows02.jpg'
+                image_size: null
                 impression_url: 'https://example.org/desktop_windows?id=0002'
                 url: 'https://www.example.org/desktop_windows'
                 position: 1


### PR DESCRIPTION
This pull request adds a new field to the `Tile` model which was added recently.

Once this has been merged and a new client Docker image was deployed to DockerHub, we should be able to get the integration tests to pass on https://github.com/mozilla-services/contile/pull/223.

Resolve #36 