### PR TITLE
Include the response content in integration-test failures 🤖

### DIFF
--- a/client/tests/test_contile.py
+++ b/client/tests/test_contile.py
@@ -31,8 +31,8 @@ def test_contile(contile_host: str, steps: List[Step]):
         r = requests.request(method, url, headers=headers)
 
         error_message = (
-            f"Expected status code {step.response.status_code}, "
-            f"but the status code in the response from Contile is {r.status_code}. "
+            f"Expected status code {step.response.status_code},\n"
+            f"but the status code in the response from Contile is {r.status_code}.\n"
             f"The response content is '{r.text}'."
         )
 

--- a/client/tests/test_contile.py
+++ b/client/tests/test_contile.py
@@ -30,7 +30,13 @@ def test_contile(contile_host: str, steps: List[Step]):
 
         r = requests.request(method, url, headers=headers)
 
-        assert r.status_code == step.response.status_code
+        error_message = (
+            f"Expected status code {step.response.status_code}, "
+            f"but the status code in the response from Contile is {r.status_code}. "
+            f"The response content is '{r.text}'."
+        )
+
+        assert r.status_code == step.response.status_code, error_message
 
         if r.status_code == 200:
             # If the response status code is 200 OK, load the response content


### PR DESCRIPTION
Below is an example for an error message for an integration-test failure: 

```text
assert r.status_code == step.response.status_code, error_message
AssertionError: Expected status code 502,
  but the status code in the response from Contile is 503.
  The response content is '522'.
assert 503 == 502
  +503
  -502
```

Resolve #50
