### PR TITLE
Fix handling for empty strings for region_code param 🐛

### DIFF
--- a/partner/app/main.py
+++ b/partner/app/main.py
@@ -105,7 +105,7 @@ async def read_tilesp(
     # region_code parameter follows ISO-3166-2 standard and validations
     # https://en.wikipedia.org/wiki/ISO_3166-2
     region_code: str = Query(
-        ..., alias="region-code", example="NY", regex="^[A-Z0-9]{1,3}$"
+        ..., alias="region-code", example="NY", regex="^([A-Z0-9]{1,3})?$"
     ),
     form_factor: str = Query(..., alias="form-factor", example="desktop"),
     os_family: str = Query(..., alias="os-family", example="macos"),

--- a/partner/app/tests/test_app.py
+++ b/partner/app/tests/test_app.py
@@ -156,6 +156,7 @@ def test_read_tilesp_validate_country_code(client, country_code):
         ("IN", "PB"),
         ("BR", "RJ"),
         ("ES", "M"),
+        ("US", ""),
     ],
 )
 def test_read_tilesp_accepted_country_region_code(client, country_code, region_code):


### PR DESCRIPTION
This is a follow-up for #59. Currently the API does not accept empty strings for the `region_code` query parameter which the API spec explicitly allows.
