### PR TITLE
Add support for multiple responses files 🌍

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     container_name: partner
     environment:
       PORT: 5000
-      RESPONSES_FILE: /tmp/partner/responses.yml
+      RESPONSES_DIR: /tmp/partner/
     volumes:
       - ./volumes/partner:/tmp/partner
   contile:

--- a/partner/app/responses.py
+++ b/partner/app/responses.py
@@ -1,0 +1,84 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import dataclasses
+import functools
+import logging
+from pathlib import Path
+from typing import Dict
+
+import yaml
+from models import ResponseFromFile
+
+logger = logging.getLogger("partner")
+
+
+# Define type aliases for the functions in this module
+FormFactor = str
+OSFamily = str
+ResponsesFromFile = Dict[FormFactor, Dict[OSFamily, ResponseFromFile]]
+
+
+@dataclasses.dataclass(eq=True, frozen=True)
+class LoaderConfig:
+    """Configuration options for the responses.yml file loader."""
+
+    responses_dir: Path
+    default_filename: str = "responses"
+
+
+def load_responses_from_file(*, config: LoaderConfig, file: Path) -> ResponsesFromFile:
+    """Load responses from the given YAML file."""
+
+    logger.debug("load responses from %s", file.relative_to(config.responses_dir))
+
+    with file.open() as f:
+        responses_yml = yaml.safe_load(f)
+
+    return {
+        form_factor: {
+            os_family: ResponseFromFile(**response)
+            for os_family, response in os_families.items()
+        }
+        for form_factor, os_families in responses_yml.items()
+    }
+
+
+@functools.lru_cache(maxsize=None)
+def load_responses(
+    *, config: LoaderConfig, country_code: str, region_code: str
+) -> ResponsesFromFile:
+    """Load responses for the given country_code and region_code combination."""
+
+    logger.debug("load responses using config %s", config)
+    logger.debug(
+        "load responses for country_code '%s' and region_code '%s'",
+        country_code,
+        region_code,
+    )
+
+    country_dir = config.responses_dir / country_code
+
+    if region_code:
+        # The region_code value is not an empty string, for example: "NY"
+        responses_file = country_dir / f"{region_code}.yml"
+
+        # If there's a responses file for the given country_code and region_code
+        # combination load the responses from that file. Do not catch
+        # exceptions, because we need those to bubble up.
+        if responses_file.exists():
+            return load_responses_from_file(config=config, file=responses_file)
+
+    # If the region_code is an empty string or there's no responses file for the
+    # given region_code, load the default responses file for the country
+    responses_file = country_dir / f"{config.default_filename}.yml"
+
+    if responses_file.exists():
+        # Load default responses for the given country, if the file exists
+        return load_responses_from_file(config=config, file=responses_file)
+
+    # Load default responses
+    return load_responses_from_file(
+        config=config, file=config.responses_dir / f"{config.default_filename}.yml"
+    )

--- a/partner/app/tests/responses/DE/responses.yml
+++ b/partner/app/tests/responses/DE/responses.yml
@@ -1,0 +1,56 @@
+# This file contains all partner responses for the /tilesp API endpoint.
+# We use form-factor and os-family to determine which response to send to Contile.
+desktop:
+    windows:
+      status_code: 200
+      headers: []
+      content:
+        tiles:
+          - id: 12345
+            name: 'Example COM'
+            click_url: 'https://example.com/desktop_windows_de?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+            image_url: 'https://example.com/desktop_windows_de01.jpg'
+            impression_url: 'https://example.com/desktop_windows_de?id=0001'
+            advertiser_url: 'https://www.example.com/desktop_windows_de'
+          - id: 56789
+            name: 'Example ORG'
+            click_url: 'https://example.org/desktop_windows_de?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+            image_url: 'https://example.org/desktop_windows_de02.jpg'
+            impression_url: 'https://example.org/desktop_windows_de?id=0002'
+            advertiser_url: 'https://www.example.org/desktop_windows_de'
+
+    macos:
+      status_code: 200
+      headers: []
+      content:
+        tiles:
+          - id: 12346
+            name: 'Example COM'
+            click_url: 'https://example.com/desktop_macos_de?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+            image_url: 'https://example.com/desktop_macos_de01.jpg'
+            impression_url: 'https://example.com/desktop_macos_de?id=0001'
+            advertiser_url: 'https://www.example.com/desktop_macos_de'
+          - id: 56790
+            name: 'Example ORG'
+            click_url: 'https://example.org/desktop_macos_de?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+            image_url: 'https://example.org/desktop_macos_de02.jpg'
+            impression_url: 'https://example.org/desktop_macos_de?id=0002'
+            advertiser_url: 'https://www.example.org/desktop_macos_de'
+
+    linux:
+      status_code: 200
+      headers: []
+      content:
+        tiles:
+          - id: 12347
+            name: 'Example COM'
+            click_url: 'https://example.com/desktop_linux_de?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+            image_url: 'https://example.com/desktop_linux_de01.jpg'
+            impression_url: 'https://example.com/desktop_linux_de?id=0001'
+            advertiser_url: 'https://www.example.com/desktop_linux_de'
+          - id: 56791
+            name: 'Example ORG'
+            click_url: 'https://example.org/desktop_linux_de?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+            image_url: 'https://example.org/desktop_linux_de02.jpg'
+            impression_url: 'https://example.org/desktop_linux_de?id=0002'
+            advertiser_url: 'https://www.example.org/desktop_linux_de'

--- a/partner/app/tests/responses/US/NY.yml
+++ b/partner/app/tests/responses/US/NY.yml
@@ -1,0 +1,56 @@
+# This file contains all partner responses for the /tilesp API endpoint.
+# We use form-factor and os-family to determine which response to send to Contile.
+desktop:
+    windows:
+      status_code: 200
+      headers: []
+      content:
+        tiles:
+          - id: 12345
+            name: 'Example COM'
+            click_url: 'https://example.com/desktop_windows_us_ny?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+            image_url: 'https://example.com/desktop_windows_us_ny01.jpg'
+            impression_url: 'https://example.com/desktop_windows_us_ny?id=0001'
+            advertiser_url: 'https://www.example.com/desktop_windows_us_ny'
+          - id: 56789
+            name: 'Example ORG'
+            click_url: 'https://example.org/desktop_windows_us_ny?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+            image_url: 'https://example.org/desktop_windows_us_ny02.jpg'
+            impression_url: 'https://example.org/desktop_windows_us_ny?id=0002'
+            advertiser_url: 'https://www.example.org/desktop_windows_us_ny'
+
+    macos:
+      status_code: 200
+      headers: []
+      content:
+        tiles:
+          - id: 12346
+            name: 'Example COM'
+            click_url: 'https://example.com/desktop_macos_us_ny?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+            image_url: 'https://example.com/desktop_macos_us_ny01.jpg'
+            impression_url: 'https://example.com/desktop_macos_us_ny?id=0001'
+            advertiser_url: 'https://www.example.com/desktop_macos_us_ny'
+          - id: 56790
+            name: 'Example ORG'
+            click_url: 'https://example.org/desktop_macos_us_ny?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+            image_url: 'https://example.org/desktop_macos_us_ny02.jpg'
+            impression_url: 'https://example.org/desktop_macos_us_ny?id=0002'
+            advertiser_url: 'https://www.example.org/desktop_macos_us_ny'
+
+    linux:
+      status_code: 200
+      headers: []
+      content:
+        tiles:
+          - id: 12347
+            name: 'Example COM'
+            click_url: 'https://example.com/desktop_linux_us_ny?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+            image_url: 'https://example.com/desktop_linux_us_ny01.jpg'
+            impression_url: 'https://example.com/desktop_linux_us_ny?id=0001'
+            advertiser_url: 'https://www.example.com/desktop_linux_us_ny'
+          - id: 56791
+            name: 'Example ORG'
+            click_url: 'https://example.org/desktop_linux_us_ny?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+            image_url: 'https://example.org/desktop_linux_us_ny02.jpg'
+            impression_url: 'https://example.org/desktop_linux_us_ny?id=0002'
+            advertiser_url: 'https://www.example.org/desktop_linux_us_ny'

--- a/partner/app/tests/responses/US/responses.yml
+++ b/partner/app/tests/responses/US/responses.yml
@@ -1,0 +1,56 @@
+# This file contains all partner responses for the /tilesp API endpoint.
+# We use form-factor and os-family to determine which response to send to Contile.
+desktop:
+    windows:
+      status_code: 200
+      headers: []
+      content:
+        tiles:
+          - id: 12345
+            name: 'Example COM'
+            click_url: 'https://example.com/desktop_windows_us?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+            image_url: 'https://example.com/desktop_windows_us01.jpg'
+            impression_url: 'https://example.com/desktop_windows_us?id=0001'
+            advertiser_url: 'https://www.example.com/desktop_windows_us'
+          - id: 56789
+            name: 'Example ORG'
+            click_url: 'https://example.org/desktop_windows_us?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+            image_url: 'https://example.org/desktop_windows_us02.jpg'
+            impression_url: 'https://example.org/desktop_windows_us?id=0002'
+            advertiser_url: 'https://www.example.org/desktop_windows_us'
+
+    macos:
+      status_code: 200
+      headers: []
+      content:
+        tiles:
+          - id: 12346
+            name: 'Example COM'
+            click_url: 'https://example.com/desktop_macos_us?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+            image_url: 'https://example.com/desktop_macos_us01.jpg'
+            impression_url: 'https://example.com/desktop_macos_us?id=0001'
+            advertiser_url: 'https://www.example.com/desktop_macos_us'
+          - id: 56790
+            name: 'Example ORG'
+            click_url: 'https://example.org/desktop_macos_us?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+            image_url: 'https://example.org/desktop_macos_us02.jpg'
+            impression_url: 'https://example.org/desktop_macos_us?id=0002'
+            advertiser_url: 'https://www.example.org/desktop_macos_us'
+
+    linux:
+      status_code: 200
+      headers: []
+      content:
+        tiles:
+          - id: 12347
+            name: 'Example COM'
+            click_url: 'https://example.com/desktop_linux_us?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+            image_url: 'https://example.com/desktop_linux_us01.jpg'
+            impression_url: 'https://example.com/desktop_linux_us?id=0001'
+            advertiser_url: 'https://www.example.com/desktop_linux_us'
+          - id: 56791
+            name: 'Example ORG'
+            click_url: 'https://example.org/desktop_linux_us?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+            image_url: 'https://example.org/desktop_linux_us02.jpg'
+            impression_url: 'https://example.org/desktop_linux_us?id=0002'
+            advertiser_url: 'https://www.example.org/desktop_linux_us'

--- a/partner/app/tests/responses/responses.yml
+++ b/partner/app/tests/responses/responses.yml
@@ -1,0 +1,87 @@
+# This file contains all partner responses for the /tilesp API endpoint.
+# We use form-factor and os-family to determine which response to send to Contile.
+desktop:
+    windows:
+      status_code: 200
+      headers: []
+      content:
+        tiles:
+          - id: 12345
+            name: 'Example COM'
+            click_url: 'https://example.com/desktop_windows?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+            image_url: 'https://example.com/desktop_windows01.jpg'
+            impression_url: 'https://example.com/desktop_windows?id=0001'
+            advertiser_url: 'https://www.example.com/desktop_windows'
+          - id: 56789
+            name: 'Example ORG'
+            click_url: 'https://example.org/desktop_windows?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+            image_url: 'https://example.org/desktop_windows02.jpg'
+            impression_url: 'https://example.org/desktop_windows?id=0002'
+            advertiser_url: 'https://www.example.org/desktop_windows'
+
+    macos:
+      status_code: 200
+      headers: []
+      content:
+        tiles:
+          - id: 12346
+            name: 'Example COM'
+            click_url: 'https://example.com/desktop_macos?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+            image_url: 'https://example.com/desktop_macos01.jpg'
+            impression_url: 'https://example.com/desktop_macos?id=0001'
+            advertiser_url: 'https://www.example.com/desktop_macos'
+          - id: 56790
+            name: 'Example ORG'
+            click_url: 'https://example.org/desktop_macos?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+            image_url: 'https://example.org/desktop_macos02.jpg'
+            impression_url: 'https://example.org/desktop_macos?id=0002'
+            advertiser_url: 'https://www.example.org/desktop_macos'
+
+    linux:
+      status_code: 200
+      headers: []
+      content:
+        tiles:
+          - id: 12347
+            name: 'Example COM'
+            click_url: 'https://example.com/desktop_linux?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+            image_url: 'https://example.com/desktop_linux01.jpg'
+            impression_url: 'https://example.com/desktop_linux?id=0001'
+            advertiser_url: 'https://www.example.com/desktop_linux'
+          - id: 56791
+            name: 'Example ORG'
+            click_url: 'https://example.org/desktop_linux?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+            image_url: 'https://example.org/desktop_linux02.jpg'
+            impression_url: 'https://example.org/desktop_linux?id=0002'
+            advertiser_url: 'https://www.example.org/desktop_linux'
+
+phone:
+    android:
+      status_code: 500
+      headers: []
+      content: {}
+
+    ios:
+      delay: 5.0
+      status_code: 200
+      headers: []
+      content:
+        tiles:
+          - id: 12348
+            name: 'Example COM'
+            click_url: 'https://example.com/desktop_ios?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+            image_url: 'https://example.com/desktop_ios01.jpg'
+            impression_url: 'https://example.com/desktop_ios?id=0001'
+            advertiser_url: 'https://www.example.com/desktop_ios'
+          - id: 56792
+            name: 'Example ORG'
+            click_url: 'https://example.org/desktop_ios?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+            image_url: 'https://example.org/desktop_ios02.jpg'
+            impression_url: 'https://example.org/desktop_ios?id=0002'
+            advertiser_url: 'https://www.example.org/desktop_ios'
+
+tablet:
+    ios:
+      status_code: 200
+      headers: []
+      content: "hello world"

--- a/partner/app/tests/test_app.py
+++ b/partner/app/tests/test_app.py
@@ -42,18 +42,18 @@ def test_read_tilesp(client):
             {
                 "id": 12346,
                 "name": "Example COM",
-                "click_url": "https://example.com/desktop_macos?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000",
-                "image_url": "https://example.com/desktop_macos01.jpg",
-                "impression_url": "https://example.com/desktop_macos?id=0001",
-                "advertiser_url": "https://www.example.com/desktop_macos",
+                "click_url": "https://example.com/desktop_macos_us_ny?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000",
+                "image_url": "https://example.com/desktop_macos_us_ny01.jpg",
+                "impression_url": "https://example.com/desktop_macos_us_ny?id=0001",
+                "advertiser_url": "https://www.example.com/desktop_macos_us_ny",
             },
             {
                 "id": 56790,
                 "name": "Example ORG",
-                "click_url": "https://example.org/desktop_macos?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A",
-                "image_url": "https://example.org/desktop_macos02.jpg",
-                "impression_url": "https://example.org/desktop_macos?id=0002",
-                "advertiser_url": "https://www.example.org/desktop_macos",
+                "click_url": "https://example.org/desktop_macos_us_ny?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A",
+                "image_url": "https://example.org/desktop_macos_us_ny02.jpg",
+                "impression_url": "https://example.org/desktop_macos_us_ny?id=0002",
+                "advertiser_url": "https://www.example.org/desktop_macos_us_ny",
             },
         ]
     }
@@ -161,6 +161,7 @@ def test_read_tilesp_validate_country_code(client, country_code):
         ("BR", "RJ"),
         ("ES", "M"),
         ("US", ""),
+        ("US", "NY"),
     ],
 )
 def test_read_tilesp_accepted_country_region_code(client, country_code, region_code):
@@ -186,26 +187,7 @@ def test_read_tilesp_accepted_country_region_code(client, country_code, region_c
     )
 
     assert response.status_code == 200
-    assert response.json() == {
-        "tiles": [
-            {
-                "id": 12346,
-                "name": "Example COM",
-                "click_url": "https://example.com/desktop_macos?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000",
-                "image_url": "https://example.com/desktop_macos01.jpg",
-                "impression_url": "https://example.com/desktop_macos?id=0001",
-                "advertiser_url": "https://www.example.com/desktop_macos",
-            },
-            {
-                "id": 56790,
-                "name": "Example ORG",
-                "click_url": "https://example.org/desktop_macos?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A",
-                "image_url": "https://example.org/desktop_macos02.jpg",
-                "impression_url": "https://example.org/desktop_macos?id=0002",
-                "advertiser_url": "https://www.example.org/desktop_macos",
-            },
-        ]
-    }
+    assert "tiles" in response.json()
 
 
 @pytest.mark.parametrize(

--- a/partner/app/tests/test_responses.py
+++ b/partner/app/tests/test_responses.py
@@ -1,0 +1,147 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+import logging
+import os
+from pathlib import Path
+
+import pytest
+from responses import LoaderConfig, load_responses
+
+
+@pytest.fixture(name="responses_dir", autouse=True)
+def fixture_cache_clear() -> None:
+    """Clear the LRU cache before every test."""
+    load_responses.cache_clear()
+
+
+@pytest.fixture(name="loader_config")
+def fixture_loader_config() -> LoaderConfig:
+    """Return a Path to the directory containing responses files."""
+    return LoaderConfig(responses_dir=Path(os.environ["RESPONSES_DIR"]))
+
+
+def test_fallback_to_default_for_country(caplog, loader_config: LoaderConfig):
+    """Test that load_responses() falls back to loading a country's default
+    responses if region_code is an empty string.
+    """
+    with caplog.at_level(logging.DEBUG, logger="partner"):
+        responses = load_responses(
+            config=loader_config, country_code="US", region_code=""
+        )
+
+    assert caplog.record_tuples == [
+        (
+            "partner",
+            logging.DEBUG,
+            f"load responses using config {loader_config}",
+        ),
+        (
+            "partner",
+            logging.DEBUG,
+            "load responses for country_code 'US' and region_code ''",
+        ),
+        (
+            "partner",
+            logging.DEBUG,
+            "load responses from US/responses.yml",
+        ),
+    ]
+
+    assert responses
+
+
+def test_fallback_to_global_default(caplog, loader_config: LoaderConfig):
+    """Test that load_responses() falls back to loading the global default
+    responses if it cannot find a responses.yml for the given country_code and
+    region_code.
+    """
+    with caplog.at_level(logging.DEBUG, logger="partner"):
+        responses = load_responses(
+            config=loader_config, country_code="GB", region_code=""
+        )
+
+    assert caplog.record_tuples == [
+        (
+            "partner",
+            logging.DEBUG,
+            f"load responses using config {loader_config}",
+        ),
+        (
+            "partner",
+            logging.DEBUG,
+            "load responses for country_code 'GB' and region_code ''",
+        ),
+        (
+            "partner",
+            logging.DEBUG,
+            "load responses from responses.yml",
+        ),
+    ]
+
+    assert responses
+
+
+def test_lru_cache(caplog, loader_config: LoaderConfig):
+    """Test that the load_responses method is cached and responses.yml files are
+    only loaded once for a given country_code and region_code combination.
+    """
+
+    with caplog.at_level(logging.DEBUG, logger="partner"):
+        load_responses(config=loader_config, country_code="US", region_code="NY")
+        load_responses(config=loader_config, country_code="DE", region_code="BE")
+
+        # The next call to load_responses is expected to be cached
+        load_responses(config=loader_config, country_code="US", region_code="NY")
+
+        load_responses(config=loader_config, country_code="GB", region_code="SCT")
+
+    assert caplog.record_tuples == [
+        (
+            "partner",
+            logging.DEBUG,
+            f"load responses using config {loader_config}",
+        ),
+        (
+            "partner",
+            logging.DEBUG,
+            "load responses for country_code 'US' and region_code 'NY'",
+        ),
+        (
+            "partner",
+            logging.DEBUG,
+            "load responses from US/NY.yml",
+        ),
+        (
+            "partner",
+            logging.DEBUG,
+            f"load responses using config {loader_config}",
+        ),
+        (
+            "partner",
+            logging.DEBUG,
+            "load responses for country_code 'DE' and region_code 'BE'",
+        ),
+        (
+            "partner",
+            logging.DEBUG,
+            "load responses from DE/responses.yml",
+        ),
+        (
+            "partner",
+            logging.DEBUG,
+            f"load responses using config {loader_config}",
+        ),
+        (
+            "partner",
+            logging.DEBUG,
+            "load responses for country_code 'GB' and region_code 'SCT'",
+        ),
+        (
+            "partner",
+            logging.DEBUG,
+            "load responses from responses.yml",
+        ),
+    ]

--- a/partner/tox.ini
+++ b/partner/tox.ini
@@ -6,7 +6,6 @@ isolated_build = False
 # Use Python 3.8 for all test environments
 basepython = python3.8
 setenv =
-    RESPONSES_FILE = {toxinidir}/app/tests/responses.yml
     RESPONSES_DIR = {toxinidir}/app/tests/responses
     PYTHONPATH = {toxinidir}/app
 

--- a/partner/tox.ini
+++ b/partner/tox.ini
@@ -7,6 +7,7 @@ isolated_build = False
 basepython = python3.8
 setenv =
     RESPONSES_FILE = {toxinidir}/app/tests/responses.yml
+    RESPONSES_DIR = {toxinidir}/app/tests/responses
     PYTHONPATH = {toxinidir}/app
 
 # The app is not set up as a Python package


### PR DESCRIPTION
This pull requests adds the capability to load different `responses.yml` files for different countries and regions to the mock API. There are fallback mechanisms in place for when a `region-code` query parameter is submitted as `""` and when there is no `responses.yml` file for a specific region or country (see the `load_responses()` implementation in `responses.py`).

URLs in the new `responses.yml` files under `partner/app/tests/responses` now contain the country or region, so we can easily verify which country and region combination was returned.

This capability is required for integration tests for different geolocations and enables us to define more integration scenarios due to the increased number of possible mock responses.

Resolve #55
