### PR TITLE
Example test for tiles dont pass the filter

### DIFF
--- a/volumes/client/scenarios.yml
+++ b/volumes/client/scenarios.yml
@@ -194,17 +194,23 @@ scenarios:
             # The following value will result in os-family: android and form-factor: tablet
             - name: User-Agent
               value: 'Mozilla/5.0 (Android; Tablet; rv:40.0) Gecko/40.0 Firefox/40.0'
+            # Contile looks up the IP address from this header value and maps it to proxy information.
+            # We use a random IP address from the range specified by the CIDR network notation '216.160.83.56/29'
+            # from https://github.com/maxmind/MaxMind-DB/blob/main/source-data/GeoLite2-City-Test.json
+            # The following value will result in country-code: US and region-code: WA
+            - name: X-Forwarded-For
+              value: '216.160.83.62'
         response:
           status_code: 200
           content:
             tiles:
-              - id: 22346
+              - id: 12349
                 name: 'Example COM'
-                click_url: 'https://example.com/desktop_android?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
-                image_url: 'https://example.com/desktop_android01.jpg'
+                click_url: 'https://example.com/us_wa_desktop_android?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+                image_url: 'https://example.com/us_wa_desktop_android01.jpg'
                 image_size: null
-                impression_url: 'https://example.com/desktop_android?id=0001'
-                url: 'https://www.example.com/desktop_android'
+                impression_url: 'https://example.com/us_wa_desktop_android?id=0001'
+                url: 'https://www.example.com/us_wa_desktop_android'
                 position: 1
 
 

--- a/volumes/client/scenarios.yml
+++ b/volumes/client/scenarios.yml
@@ -183,7 +183,8 @@ scenarios:
           status_code: 403 # Forbidden
           content: 700
 
-  - name: success_tablet_android_return_tiles_that_pass_filter
+  - name: success_tablet_android_return_only_tiles_that_pass_filter
+    # This is not a working test but only for documentation purpose
     description: Test that Contile only returns tiles that pass the filter.
     steps:
       - request:
@@ -191,26 +192,23 @@ scenarios:
           path: '/v1/tiles'
           headers:
             # Contile maps the User-Agent Header value to os-family and form-factor parameters
-            # The following value will result in os-family: android and form-factor: tablet
+            # The following value will result in os-family: android and form-factor: phone(android-tablets falls under 'phones')
+            # This won't return a 200 response but a 500 as contile has cached the response from the previous scenario with
+            # os-family: android and form-factor: phone
             - name: User-Agent
-              value: 'Mozilla/5.0 (Android; Tablet; rv:40.0) Gecko/40.0 Firefox/40.0'
-            # Contile looks up the IP address from this header value and maps it to proxy information.
-            # We use a random IP address from the range specified by the CIDR network notation '216.160.83.56/29'
-            # from https://github.com/maxmind/MaxMind-DB/blob/main/source-data/GeoLite2-City-Test.json
-            # The following value will result in country-code: US and region-code: WA
-            - name: X-Forwarded-For
-              value: '216.160.83.62'
+              value: 'Mozilla/5.0 (Android; Tablet; rv:92.0) Gecko/92.0 Firefox/92.0'
+            # The response below returned only 1 tile because the other tile (.NET) didn't pass the filter specification in the adm_settings.json
         response:
           status_code: 200
           content:
             tiles:
               - id: 12349
                 name: 'Example COM'
-                click_url: 'https://example.com/us_wa_desktop_android?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
-                image_url: 'https://example.com/us_wa_desktop_android01.jpg'
+                click_url: 'https://example.com/desktop_android?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+                image_url: 'https://example.com/desktop_android01.jpg'
                 image_size: null
-                impression_url: 'https://example.com/us_wa_desktop_android?id=0001'
-                url: 'https://www.example.com/us_wa_desktop_android'
+                impression_url: 'https://example.com/desktop_android?id=0001'
+                url: 'https://www.example.com/desktop_android'
                 position: 1
 
 

--- a/volumes/client/scenarios.yml
+++ b/volumes/client/scenarios.yml
@@ -192,7 +192,9 @@ scenarios:
           path: '/v1/tiles'
           headers:
             # Contile maps the User-Agent Header value to os-family and form-factor parameters
-            # The following value will result in os-family: android and form-factor: phone(android-tablets falls under 'phones')
+            # The following value will result in os-family: android and form-factor: phone
+            # Currently woothee categorizes Android tablets as phones
+            # (the library Contile uses for parsing the User-Agent Header)
             # This won't return a 200 response but a 500 as contile has cached the response from the previous scenario with
             # os-family: android and form-factor: phone
             - name: User-Agent

--- a/volumes/client/scenarios.yml
+++ b/volumes/client/scenarios.yml
@@ -199,7 +199,7 @@ scenarios:
             # os-family: android and form-factor: phone
             - name: User-Agent
               value: 'Mozilla/5.0 (Android; Tablet; rv:92.0) Gecko/92.0 Firefox/92.0'
-            # The response below returned only 1 tile because the other tile (.NET) didn't pass the filter specification in the adm_settings.json
+            # We expect only 1 tile because 'Example NET' is not an expected advertiser (per adm_settings.json) 
         response:
           status_code: 200
           content:

--- a/volumes/client/scenarios.yml
+++ b/volumes/client/scenarios.yml
@@ -195,22 +195,20 @@ scenarios:
             # The following value will result in os-family: android and form-factor: phone
             # Currently woothee categorizes Android tablets as phones
             # (the library Contile uses for parsing the User-Agent Header)
-            # This won't return a 200 response but a 500 as contile has cached the response from the previous scenario with
-            # os-family: android and form-factor: phone
             - name: User-Agent
               value: 'Mozilla/5.0 (Android; Tablet; rv:92.0) Gecko/92.0 Firefox/92.0'
-            # We expect only 1 tile because 'Example NET' is not an expected advertiser (per adm_settings.json) 
+            # We expect only 1 tile because 'Example NET' is not an expected advertiser (per adm_settings.json)
+            # This won't return a 200 response but a 500 as contile has cached the response from the previous test
+            # scenario 'error_phone_android_reqwest_error'
         response:
           status_code: 200
           content:
             tiles:
               - id: 12349
                 name: 'Example COM'
-                click_url: 'https://example.com/desktop_android?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
-                image_url: 'https://example.com/desktop_android01.jpg'
+                click_url: 'https://example.com/tablet_android?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+                image_url: 'https://example.com/tablet_android01.jpg'
                 image_size: null
-                impression_url: 'https://example.com/desktop_android?id=0001'
-                url: 'https://www.example.com/desktop_android'
+                impression_url: 'https://example.com/tablet_android?id=0001'
+                url: 'https://www.example.com/tablet_android'
                 position: 1
-
-

--- a/volumes/client/scenarios.yml
+++ b/volumes/client/scenarios.yml
@@ -197,10 +197,10 @@ scenarios:
             # (the library Contile uses for parsing the User-Agent Header)
             - name: User-Agent
               value: 'Mozilla/5.0 (Android; Tablet; rv:92.0) Gecko/92.0 Firefox/92.0'
-            # We expect only 1 tile because 'Example NET' is not an expected advertiser (per adm_settings.json)
-            # This won't return a 200 response but a 500 as contile has cached the response from the previous test
-            # scenario 'error_phone_android_reqwest_error'
         response:
+          # We expect only 1 tile because 'Example NET' is not an expected advertiser (per adm_settings.json)
+          # This won't return a 200 response but a 500 as contile has cached the response from the previous test
+          # scenario 'error_phone_android_reqwest_error'
           status_code: 200
           content:
             tiles:

--- a/volumes/client/scenarios.yml
+++ b/volumes/client/scenarios.yml
@@ -182,3 +182,29 @@ scenarios:
         response:
           status_code: 403 # Forbidden
           content: 700
+
+  - name: success_tablet_android_return_tiles_that_pass_filter
+    description: Test that Contile only returns tiles that pass the filter.
+    steps:
+      - request:
+          method: GET
+          path: '/v1/tiles'
+          headers:
+            # Contile maps the User-Agent Header value to os-family and form-factor parameters
+            # The following value will result in os-family: android and form-factor: tablet
+            - name: User-Agent
+              value: 'Mozilla/5.0 (Android; Tablet; rv:40.0) Gecko/40.0 Firefox/40.0'
+        response:
+          status_code: 200
+          content:
+            tiles:
+              - id: 22346
+                name: 'Example COM'
+                click_url: 'https://example.com/desktop_android?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+                image_url: 'https://example.com/desktop_android01.jpg'
+                image_size: null
+                impression_url: 'https://example.com/desktop_android?id=0001'
+                url: 'https://www.example.com/desktop_android'
+                position: 1
+
+

--- a/volumes/partner/responses.yml
+++ b/volumes/partner/responses.yml
@@ -93,7 +93,7 @@ tablet:
         tiles:
           - id: 12349
             name: 'Example COM'
-            click_url: 'https://example.com/desktop_android?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+            click_url: 'https://example.com/tablet_android?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
             image_url: 'https://example.com/desktop_android01.jpg'
             impression_url: 'https://example.com/desktop_android?id=0001'
             advertiser_url: 'https://www.example.com/desktop_android'

--- a/volumes/partner/responses.yml
+++ b/volumes/partner/responses.yml
@@ -91,13 +91,13 @@ tablet:
       headers: []
       content:
         tiles:
-          - id: 12345
-            name: 'Example COM
-            click_url: 'https://example.com/desktop_android?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
-            image_url: 'https://example.com/desktop_android01.jpg'
-            impression_url: 'https://example.com/desktop_android?id=0001'
-            advertiser_url: 'https://www.example.com/desktop_android'
-          - id: 56789
+          - id: 12349
+            name: 'Example COM'
+            click_url: 'https://example.com/us_wa_desktop_android?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+            image_url: 'https://example.com/us_wa_desktop_android01.jpg'
+            impression_url: 'https://example.com/us_wa_desktop_android?id=0001'
+            advertiser_url: 'https://www.example.com/us_wa_desktop_android'
+          - id: 56793
             name: 'Example NET'
             click_url: 'https://example.net/desktop_android?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
             image_url: 'https://example.net/desktop_android02.jpg'

--- a/volumes/partner/responses.yml
+++ b/volumes/partner/responses.yml
@@ -93,12 +93,12 @@ tablet:
         tiles:
           - id: 12349
             name: 'Example COM'
-            click_url: 'https://example.com/us_wa_desktop_android?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
-            image_url: 'https://example.com/us_wa_desktop_android01.jpg'
-            impression_url: 'https://example.com/us_wa_desktop_android?id=0001'
-            advertiser_url: 'https://www.example.com/us_wa_desktop_android'
+            click_url: 'https://example.com/desktop_android?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+            image_url: 'https://example.com/desktop_android01.jpg'
+            impression_url: 'https://example.com/desktop_android?id=0001'
+            advertiser_url: 'https://www.example.com/desktop_android'
           - id: 56793
-            name: 'Example NET'
+            name: 'Example NET' # this tile doesn't conforms to the filter specs (.NET is not an acceptable host in adm_settings.json)
             click_url: 'https://example.net/desktop_android?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
             image_url: 'https://example.net/desktop_android02.jpg'
             impression_url: 'https://example.net/desktop_android?id=0002'

--- a/volumes/partner/responses.yml
+++ b/volumes/partner/responses.yml
@@ -85,3 +85,21 @@ tablet:
       status_code: 200
       headers: []
       content: "hello world"
+
+    android:
+      status_code: 200
+      headers: []
+      content:
+        tiles:
+          - id: 12345
+            name: 'Example COM
+            click_url: 'https://example.com/desktop_android?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
+            image_url: 'https://example.com/desktop_android01.jpg'
+            impression_url: 'https://example.com/desktop_android?id=0001'
+            advertiser_url: 'https://www.example.com/desktop_android'
+          - id: 56789
+            name: 'Example NET'
+            click_url: 'https://example.net/desktop_android?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+            image_url: 'https://example.net/desktop_android02.jpg'
+            impression_url: 'https://example.net/desktop_android?id=0002'
+            advertiser_url: 'https://www.example.net/desktop_android'

--- a/volumes/partner/responses.yml
+++ b/volumes/partner/responses.yml
@@ -98,7 +98,7 @@ tablet:
             impression_url: 'https://example.com/desktop_android?id=0001'
             advertiser_url: 'https://www.example.com/desktop_android'
           - id: 56793
-            name: 'Example NET' # this tile doesn't conforms to the filter specs (.NET is not an acceptable host in adm_settings.json)
+            name: 'Example NET' # this tile is from an unexpected advertiser (per adm_settings.json)
             click_url: 'https://example.net/desktop_android?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
             image_url: 'https://example.net/desktop_android02.jpg'
             impression_url: 'https://example.net/desktop_android?id=0002'

--- a/volumes/partner/responses.yml
+++ b/volumes/partner/responses.yml
@@ -94,12 +94,12 @@ tablet:
           - id: 12349
             name: 'Example COM'
             click_url: 'https://example.com/tablet_android?version=16.0.0&key=22.1&ci=6.2&ctag=1612376952400200000'
-            image_url: 'https://example.com/desktop_android01.jpg'
-            impression_url: 'https://example.com/desktop_android?id=0001'
-            advertiser_url: 'https://www.example.com/desktop_android'
+            image_url: 'https://example.com/tablet_android01.jpg'
+            impression_url: 'https://example.com/tablet_android?id=0001'
+            advertiser_url: 'https://www.example.com/tablet_android'
           - id: 56793
             name: 'Example NET' # this tile is from an unexpected advertiser (per adm_settings.json)
-            click_url: 'https://example.net/desktop_android?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
-            image_url: 'https://example.net/desktop_android02.jpg'
-            impression_url: 'https://example.net/desktop_android?id=0002'
-            advertiser_url: 'https://www.example.net/desktop_android'
+            click_url: 'https://example.net/tablet_android?version=16.0.0&key=7.2&ci=8.9&ctag=E1DE38C8972D0281F5556659A'
+            image_url: 'https://example.net/tablet_android02.jpg'
+            impression_url: 'https://example.net/tablet_android?id=0002'
+            advertiser_url: 'https://www.example.net/tablet_android'


### PR DESCRIPTION
**This is not a working test.** 
It is just to document how to write an example test for Tiles that don't pass the filter.
Added test `success_tablet_android_return_tiles_that_pass_filter` in `scenarios.yml` file that contains `user-agent` as `form-factor: tablet` and `os-family: andoid` and `country-code: US` and `region code: WA` to demonstrate the use of geo-location as well for this example test. 
In the `response.yml` file I added a response from` tablet: android` having the second response that doesn't conform to the filter specification and hence for this test only the first response should be returned.