### PR TITLE
Make dma-code query parameter required 🌎

### DIFF
--- a/partner/app/main.py
+++ b/partner/app/main.py
@@ -106,15 +106,13 @@ async def read_tilesp(
     region_code: str = Query(
         ..., alias="region-code", example="NY", regex="^([A-Z0-9]{1,3})?$"
     ),
+    # dma_code parameter represents a Designated Marketing Area code in the US.
+    dma_code: str = Query(..., alias="dma-code", example="532", regex="^([0-9]+)?$"),
     form_factor: str = Query(..., alias="form-factor", example="desktop"),
     os_family: str = Query(..., alias="os-family", example="macos"),
     v: str = Query(..., example="1.0"),
     out: str = Query("json", example="json"),
     results: int = Query(1, example=2),
-    # dma_code parameter represents a Designated Marketing Area code in the US.
-    # Make it optional until it's included in every request from Contile:
-    # https://github.com/mozilla-services/contile/pull/235
-    dma_code: str = Query("", alias="dma-code", example="532", regex="^([0-9]+)?$"),
 ):
     """Endpoint for requests from Contile."""
 

--- a/partner/app/tests/test_app.py
+++ b/partner/app/tests/test_app.py
@@ -148,23 +148,25 @@ def test_read_tilesp_validate_country_code(client, country_code):
 
 
 @pytest.mark.parametrize(
-    "country_code, region_code",
+    "country_code, region_code, dma_code",
     [
-        ("CA", "BC"),
-        ("DE", "BE"),
-        ("GB", "SCT"),
-        ("FR", "BRE"),
-        ("AU", "WA"),
-        ("IT", "52"),
-        ("MX", "CHH"),
-        ("IN", "PB"),
-        ("BR", "RJ"),
-        ("ES", "M"),
-        ("US", ""),
-        ("US", "NY"),
+        ("CA", "BC", ""),
+        ("DE", "BE", ""),
+        ("GB", "SCT", ""),
+        ("FR", "BRE", ""),
+        ("AU", "WA", ""),
+        ("IT", "52", ""),
+        ("MX", "CHH", ""),
+        ("IN", "PB", ""),
+        ("BR", "RJ", ""),
+        ("ES", "M", ""),
+        ("US", "", ""),
+        ("US", "NY", "532"),
     ],
 )
-def test_read_tilesp_accepted_country_region_code(client, country_code, region_code):
+def test_read_tilesp_accepted_country_region_code(
+    client, country_code, region_code, dma_code
+):
     """Test that the API endpoint accepts region codes from countries Contile
     has been rolled out to for the region-code query parameter.
 
@@ -179,6 +181,7 @@ def test_read_tilesp_accepted_country_region_code(client, country_code, region_c
             "sub2": "sub2",
             "country-code": country_code,
             "region-code": region_code,
+            "dma-code": dma_code,
             "form-factor": "desktop",
             "os-family": "macos",
             "v": "1.0",


### PR DESCRIPTION
Now that Contile always sends a valid dma-code value or `""` we can make the query parameter required.

See https://github.com/mozilla-services/contile/pull/235
