### PR TITLE
Delete position field from Tile model

### DIFF
--- a/client/tests/models.py
+++ b/client/tests/models.py
@@ -32,7 +32,6 @@ class Tile(BaseModel, extra=Extra.allow):
     image_size: Optional[int]
     impression_url: str
     url: str
-    position: int
 
 
 class Tiles(BaseModel):

--- a/client/tests/test_contile.py
+++ b/client/tests/test_contile.py
@@ -41,8 +41,10 @@ def test_contile(contile_host: str, steps: List[Step]):
         if r.status_code == 200:
             # If the response status code is 200 OK, load the response content
             # into a Python dict and generate a dict from the response model
-            assert r.json() == step.response.content.dict()
-            continue
+            resp = step.response.content
+            if not(isinstance(resp, dict)):
+                resp = resp.dict()
+            assert r.json() == resp
 
         if r.status_code == 204:
             # If the response status code is 204 No Content, load the response content

--- a/client/tests/test_contile.py
+++ b/client/tests/test_contile.py
@@ -42,9 +42,10 @@ def test_contile(contile_host: str, steps: List[Step]):
             # If the response status code is 200 OK, load the response content
             # into a Python dict and generate a dict from the response model
             resp = step.response.content
-            if not(isinstance(resp, dict)):
+            if not (isinstance(resp, dict)):
                 resp = resp.dict()
             assert r.json() == resp
+            continue
 
         if r.status_code == 204:
             # If the response status code is 204 No Content, load the response content

--- a/client/tests/test_contile.py
+++ b/client/tests/test_contile.py
@@ -41,10 +41,11 @@ def test_contile(contile_host: str, steps: List[Step]):
         if r.status_code == 200:
             # If the response status code is 200 OK, load the response content
             # into a Python dict and generate a dict from the response model
-            resp = step.response.content
-            if not (isinstance(resp, dict)):
-                resp = resp.dict()
-            assert r.json() == resp
+            try:
+                assert r.json() == step.response.content.dict()
+            except AttributeError as e:
+                print("Response failed to resolve into a Tile object. Have the response fields changed?")
+                raise
             continue
 
         if r.status_code == 204:

--- a/client/tests/test_contile.py
+++ b/client/tests/test_contile.py
@@ -41,13 +41,7 @@ def test_contile(contile_host: str, steps: List[Step]):
         if r.status_code == 200:
             # If the response status code is 200 OK, load the response content
             # into a Python dict and generate a dict from the response model
-            try:
-                assert r.json() == step.response.content.dict()
-            except AttributeError as e:
-                print(
-                    "Response failed to resolve into a Tile object. Have the response fields changed?"
-                )
-                raise
+            assert r.json() == step.response.content.dict()
             continue
 
         if r.status_code == 204:

--- a/client/tests/test_contile.py
+++ b/client/tests/test_contile.py
@@ -44,7 +44,9 @@ def test_contile(contile_host: str, steps: List[Step]):
             try:
                 assert r.json() == step.response.content.dict()
             except AttributeError as e:
-                print("Response failed to resolve into a Tile object. Have the response fields changed?")
+                print(
+                    "Response failed to resolve into a Tile object. Have the response fields changed?"
+                )
                 raise
             continue
 

--- a/partner/config/gunicorn_conf.py
+++ b/partner/config/gunicorn_conf.py
@@ -8,10 +8,11 @@ import pathlib
 import yaml
 
 port = os.getenv("PORT", "8000")
+root = os.getenv("ROOT", "")
 
 accesslog = "-"
 errorlog = "-"
 workers = 4
 
-with pathlib.Path("config/logging.yml").open() as f:
+with pathlib.Path(root + "config/logging.yml").open() as f:
     logconfig_dict = yaml.safe_load(f)


### PR DESCRIPTION
Not sure why, but in `test_contile.py`, `step.response.content` (line 44) is already a `dict` in a number of cases (See [failed build](https://app.circleci.com/pipelines/github/mozilla-services/contile/704/workflows/ef078292-d86f-4cd4-be33-6155313138ba/jobs/2668). I added a hack to check the instance type and only call `dict()` if required. 

