### PR TITLE
Add support for multiple API endpoints 📱

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     environment:
       PORT: 5000
       RESPONSES_DIR: /tmp/partner/
+      ACCEPTED_MOBILE_FORM_FACTORS: 'phone,tablet'
+      ACCEPTED_DESKTOP_FORM_FACTORS: 'desktop'
     volumes:
       - ./volumes/partner:/tmp/partner
   contile:
@@ -17,7 +19,8 @@ services:
     links:
       - partner
     environment:
-      CONTILE_ADM_ENDPOINT_URL: http://partner:5000/tilesp
+      CONTILE_ADM_ENDPOINT_URL: http://partner:5000/tilesp/desktop
+      CONTILE_ADM_MOBILE_ENDPOINT_URL: http://partner:5000/tilesp/mobile
       CONTILE_ADM_QUERY_TILE_COUNT: 2
       CONTILE_ADM_SETTINGS: /tmp/contile/adm_settings.json
       # Timeout requests to the ADM server after this many seconds (default: 5)
@@ -26,6 +29,8 @@ services:
       CONTILE_HOST: 0.0.0.0
       CONTILE_HUMAN_LOGS: 1
       CONTILE_PORT: 8000
+      CONTILE_ADM_SUB1: "123456789"
+      CONTILE_ADM_PARTNER_ID: "demofeed"
       RUST_LOG: main,contile=INFO
     volumes:
       - ./volumes/contile:/tmp/contile

--- a/partner/app/tests/test_app.py
+++ b/partner/app/tests/test_app.py
@@ -21,7 +21,7 @@ def test_read_tilesp(client):
     example values for the required query parameters from the API specification.
     """
     response = client.get(
-        "/tilesp",
+        "/tilesp/desktop",
         params={
             "partner": "demofeed",
             "sub1": "123456789",
@@ -75,7 +75,7 @@ def test_read_tilesp_validate_sub2(client, sub2):
     See https://github.com/mozilla-services/contile-integration-tests/issues/38
     """
     response = client.get(
-        "/tilesp",
+        "/tilesp/desktop",
         params={
             "partner": "demofeed",
             "sub1": "123456789",
@@ -124,7 +124,7 @@ def test_read_tilesp_validate_country_code(client, country_code):
     See https://github.com/mozilla-services/contile-integration-tests/issues/39
     """
     response = client.get(
-        "/tilesp",
+        "/tilesp/desktop",
         params={
             "partner": "demofeed",
             "sub1": "123456789",
@@ -174,7 +174,7 @@ def test_read_tilesp_accepted_country_region_code(
     See https://github.com/mozilla-services/contile-integration-tests/issues/40
     """
     response = client.get(
-        "/tilesp",
+        "/tilesp/desktop",
         params={
             "partner": "demofeed",
             "sub1": "123456789",
@@ -215,7 +215,7 @@ def test_read_tilesp_validate_region_code(client, region_code):
     See https://github.com/mozilla-services/contile-integration-tests/issues/40
     """
     response = client.get(
-        "/tilesp",
+        "/tilesp/desktop",
         params={
             "partner": "demofeed",
             "sub1": "123456789",
@@ -257,7 +257,7 @@ def test_read_tilesp_validate_dma_code(client, dma_code):
     See https://github.com/mozilla-services/contile-integration-tests/issues/62
     """
     response = client.get(
-        "/tilesp",
+        "/tilesp/desktop",
         params={
             "partner": "demofeed",
             "sub1": "123456789",
@@ -301,7 +301,7 @@ def test_read_tilesp_error_for_unknown_query_params(client):
     See https://github.com/mozilla-services/contile-integration-tests/issues/41
     """
     response = client.get(
-        "/tilesp",
+        "/tilesp/desktop",
         params={
             "partner": "demofeed",
             "sub1": "123456789",

--- a/partner/tox.ini
+++ b/partner/tox.ini
@@ -7,6 +7,8 @@ isolated_build = False
 basepython = python3.8
 setenv =
     RESPONSES_DIR = {toxinidir}/app/tests/responses
+    ACCEPTED_MOBILE_FORM_FACTORS = phone,tablet
+    ACCEPTED_DESKTOP_FORM_FACTORS = desktop
     PYTHONPATH = {toxinidir}/app
 
 # The app is not set up as a Python package


### PR DESCRIPTION
This pull request adds support for multiple partner API endpoints and the capability to these endpoints to return a `400 Bad Request` for requests that have a `form-factor` query parameter value that is not accepted. For example we can return an error response when an incoming HTTP request to the **desktop** API endpoint has `form-factor` of `tablet`.

Resolve #149
