### PR TITLE
Update Dependabot schedule to weekly on Fridays 📦

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,8 @@ updates:
   - package-ecosystem: "pip"
     directory: "partner/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "friday"
     labels:
       - "Dependabot"
       - "dependencies"
@@ -12,7 +13,8 @@ updates:
   - package-ecosystem: "pip"
     directory: "client/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "friday"
     labels:
       - "Dependabot"
       - "dependencies"


### PR DESCRIPTION
Currently Dependabot will create pull request for Python package upgrades every day. I suggest we reduce that frequency to reduce the number of notifications and open pull requests.
