### PR TITLE
Upgrade circleci/docker orb to v2.1.0 🤖

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@
 version: 2.1
 
 orbs:
-  docker: circleci/docker@1.6.0
+  docker: circleci/docker@2.1.0
 
 jobs:
   run_checks:


### PR DESCRIPTION
This hopefully resolves the following error for the Docker image push jobs:
`This job was rejected because the image is unavailable`

For reference:
* https://github.com/CircleCI-Public/docker-orb/pull/86
* https://circleci.com/blog/ubuntu-14-16-image-deprecation/
