### PR TITLE
Upgrade circleci/docker orb to v2.1.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@
 version: 2.1
 
 orbs:
-  docker: circleci/docker@2.1.0
+  docker: circleci/docker@2.1.1
 
 jobs:
   run_checks:


### PR DESCRIPTION
Update the CircleCI docker orb version to latest

For reference:
- https://circleci.com/developer/orbs/orb/circleci/docker
- https://github.com/CircleCI-Public/docker-orb/releases/tag/v2.1.1